### PR TITLE
fix: add localnet to cluster

### DIFF
--- a/packages/react-sdk/src/hooks/useGum.ts
+++ b/packages/react-sdk/src/hooks/useGum.ts
@@ -4,7 +4,13 @@ import { AnchorWallet } from '@solana/wallet-adapter-react';
 import { SDK } from '@gumhq/sdk';
 import { Connection, ConfirmOptions, Cluster } from '@solana/web3.js';
 
-const useGum = (wallet: AnchorWallet, connection: Connection, opts: ConfirmOptions, cluster: Cluster, graphqlClient?: GraphQLClient) => {
+const useGum = (
+  wallet: AnchorWallet,
+  connection: Connection,
+  opts: ConfirmOptions,
+  cluster: Cluster | "localnet",
+  graphqlClient?: GraphQLClient
+) => {
   const sdk = useMemo(() => {
     return new SDK(wallet, connection, opts, cluster, graphqlClient);
   }, [wallet]);


### PR DESCRIPTION
Adding `localnet` to cluster options makes it easier to run SDK locally using `yarn link` if required.

https://github.com/gumhq/sdk/blob/f66494c3b4d06590aef3e2ef83f06c72d58ec459/packages/react-sdk/src/hooks/useGum.ts#L7-L10